### PR TITLE
商品の名前、価格などの表示の実装

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,10 +127,11 @@
     <ul class='item-lists'>
 
     <% @items.each do |item| %>
-     <li class='list'>
-      <%= link_to "#" do %>
-          <div class='item-img-content'>
-            <%= image_tag item.image, class: "item-img" %>
+
+      <li class='list'>
+        <%= link_to "#" do %>
+        <div class='item-img-content'>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -145,6 +146,7 @@
           </h3>
           <div class='item-price'>
             <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
+
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -154,8 +156,8 @@
      <% end %>
 
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
     <% end %>
+
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>


### PR DESCRIPTION
#what 商品画像、名前、価格、配送料の負担の表示の実装
#why 商品表示されていないとデータベースに保存されているだけで意味がないので、表示させるひつようがある

ログインユーザー以外でも商品一覧がみれる
https://gyazo.com/374059af447592f305fde29789ef4f61

ログインユーザーでも商品一覧が見れる
https://gyazo.com/9897e6c00ad430d2d195f3a053bdb38e